### PR TITLE
Added logic to cleanup the apt cache.

### DIFF
--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -18,4 +18,5 @@ RUN apt-get update \
     && wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-ubuntu-x64.latest.deb \
     && dpkg --force-depends -i dotnet-ubuntu-x64.latest.deb \
     && apt-get -f -y --no-remove install \
-    && rm dotnet-ubuntu-x64.latest.deb
+    && rm dotnet-ubuntu-x64.latest.deb \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This reduces the image size by ~21mb.  This resolves #5.

@naamunds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/dotnet-docker-preview/6)
<!-- Reviewable:end -->
