### PR TITLE
Update Dockerfile to be Debian based

### DIFF
--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -8,7 +8,7 @@ ENV LTTNG_UST_REGISTER_TIMEOUT 0
 
 # Install .NET CLI dependencies
 RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6 main" > /etc/apt/sources.list.d/llvm.list \
-    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
+    && wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         clang-3.5 \
@@ -27,8 +27,8 @@ RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6
     && rm -rf /var/lib/apt/lists/*
 
 # Install .NET CLI
-RUN wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-dev-debian-x64.latest.tar.gz \
-    && mkdir /usr/share/dotnet \
-    && tar -zxvf dotnet-dev-debian-x64.latest.tar.gz -C /usr/share/dotnet \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet-dev-debian-x64.latest.tar.gz
+RUN wget -q https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-dev-debian-x64.latest.tar.gz \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet-dev-debian-x64.latest.tar.gz -C /usr/share/dotnet \
+    && rm dotnet-dev-debian-x64.latest.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Install .NET CLI
+# Install the LKG preview build of the .NET CLI
 RUN wget -q https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-dev-debian-x64.latest.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet-dev-debian-x64.latest.tar.gz -C /usr/share/dotnet \

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:trusty-scm
+FROM buildpack-deps:jessie-scm
 
 # Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
 # fix (https://github.com/docker/docker/issues/20818). This workaround allows
@@ -6,23 +6,29 @@ FROM buildpack-deps:trusty-scm
 # the restart_syscall made by LTTng which causes a failed assertion.
 ENV LTTNG_UST_REGISTER_TIMEOUT 0
 
-# Install the LKG preview build of the .NET CLI. This is done by downloading
-# and installing the .deb file directly because there is a significant latency
-# between the publishing of a .NET CLI Debian package and its availability on
-# the package repository, so the simple "apt-get install dotnet" might not
-# pick up the latest build.
-#
-# Because the dpkg command cannot install dependencies, treat errors as
-# warnings and then use apt-get to install the dependencies.
-RUN apt-get update \
-    && wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-host-ubuntu-x64.latest.deb \
-    && wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-sharedframework-ubuntu-x64.latest.deb \
-    && wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-sdk-ubuntu-x64.latest.deb \
-    && dpkg --force-depends -i dotnet-host-ubuntu-x64.latest.deb \
-    && dpkg --force-depends -i dotnet-sharedframework-ubuntu-x64.latest.deb \
-    && dpkg --force-depends -i dotnet-sdk-ubuntu-x64.latest.deb \
-    && apt-get -f -y --no-remove install \
-    && rm dotnet-host-ubuntu-x64.latest.deb \
-    && rm dotnet-sharedframework-ubuntu-x64.latest.deb \
-    && rm dotnet-sdk-ubuntu-x64.latest.deb \
+# Install .NET CLI dependencies
+RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6 main" > /etc/apt/sources.list.d/llvm.list \
+    && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang-3.5 \
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libicu52 \
+        liblldb-3.6 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        libstdc++6 \
+        libtinfo5 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
     && rm -rf /var/lib/apt/lists/*
+
+# Install .NET CLI
+RUN wget https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-dev-debian-x64.latest.tar.gz \
+    && mkdir /usr/share/dotnet \
+    && tar -zxvf dotnet-dev-debian-x64.latest.tar.gz -C /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet-dev-debian-x64.latest.tar.gz


### PR DESCRIPTION
All of our Docker images will be Debian based for RC2 (https://github.com/dotnet/dotnet-docker/issues/11).  CLI now supports Debian therefore the preview image was updated accordingly.  Keep in mind the CLI Debian installer work is out of scope for RC2 therefore the Dockerfile needs to contain the logic to install CLI.

/cc @naamunds, @dleeapho 