### PR TITLE
Removed the clang-3.5 and liblldb-3.6 packages from the image

### DIFF
--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -7,16 +7,12 @@ FROM buildpack-deps:jessie-scm
 ENV LTTNG_UST_REGISTER_TIMEOUT 0
 
 # Install .NET CLI dependencies
-RUN echo "deb [arch=amd64] http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.6 main" > /etc/apt/sources.list.d/llvm.list \
-    && wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key|apt-key add - \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        clang-3.5 \
         libc6 \
         libcurl3 \
         libgcc1 \
         libicu52 \
-        liblldb-3.6 \
         liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -12,11 +12,11 @@ RUN apt-get update \
         libc6 \
         libcurl3 \
         libgcc1 \
+        libgssapi-krb5-2 \
         libicu52 \
         liblttng-ust0 \
         libssl1.0.0 \
         libstdc++6 \
-        libtinfo5 \
         libunwind8 \
         libuuid1 \
         zlib1g \


### PR DESCRIPTION
Fixes #18 

@naamunds 